### PR TITLE
Rely on automatic dependency cache mounts

### DIFF
--- a/.wodby/pipeline.yml
+++ b/.wodby/pipeline.yml
@@ -17,7 +17,7 @@ jobs:
     - run: wodby ci init $WODBY_BUILD_ID
 
     # use wodby ci run instead of wodby ci build with buildx cache because we need to scaffold web/ for nginx image.
-    - run: wodby ci run -v $HOME/.composer:/home/wodby/.composer -- composer install -n --no-ansi
+    - run: wodby ci run -- composer install -n --no-ansi
     - run: wodby ci build
 
     - cache_save:


### PR DESCRIPTION
## Summary

`wodby ci run` detects the dependency cache from the service image and mounts it automatically, so the explicit bind mount is no longer needed.

The `cache_restore` and `cache_save` steps stay. Those persist the cache between builds, which is separate from mounting it into the container, and the automatic mount uses the same host location they already save: `$HOME/.npm` for npm, and `$HOME/.composer/cache` for Composer, which sits inside the `~/.composer` path already being persisted.

Use `--no-cache` to opt out, or `--cache <profile>` to select profiles explicitly instead of detecting them.